### PR TITLE
Check Schema Exists First before creating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 target/
 dbt_modules/
 logs/
+**/*.DS_Store

--- a/macros/dmt_get_test_sql.sql
+++ b/macros/dmt_get_test_sql.sql
@@ -30,7 +30,10 @@
 
         {# SQL Server requires us to specify a table type because it calls `drop_relation_script()` from `create_table_as()`.
         I'd prefer to use something like RelationType.table, but can't find a way to access the relation types #}
-        {% do adapter.create_schema(api.Relation.create(database=model.database, schema=model.schema)) %}
+        {% if not adapter.check_schema_exists(database=model.database, schema=model.schema) %}
+            {% do adapter.create_schema(api.Relation.create(database=model.database, schema=model.schema)) %}
+        {% endif %}
+
         {% set mock_model_relation = make_temp_relation(dbt_datamocktool._get_model_to_mock(model), suffix=('_dmt_' ~ modules.datetime.datetime.now().strftime("%S%f"))) %}
 
         {% do run_query(create_table_as(true, mock_model_relation, ns.test_sql)) %}


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality
- [ ] a breaking change

## Description & motivation
This simply checks for whether the schema exists before attempting to create the schema. This is helpful because some users (like me) have no permission to create schema on redshift directly. Because of that, the adapter.create_schema line fails, and I won't be able to run tests locally.

I, however, do have the permission to check what schemas exist.

the check_schema_exists is found [here](https://github.com/dbt-labs/dbt-core/blob/9bdf5fe74aca9d3366be594c498332cd8ae2c1f1/core/dbt/adapters/sql/impl.py#L245) but not documented on the [docs](https://docs.getdbt.com/reference/dbt-jinja-functions/adapter)

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [x] Redshift
    - [ ] Snowflake
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my macros (and models if applicable)
