### PR TITLE
changed path structure to match v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Using dmt, you can create mock CSV seeds to stand in for the sources and refs th
 and test that the model produces the desired output (using another CSV seed).
 
 ## Requirements
-* dbt version 0.19.2 or greater
+* dbt version:
+    * 1.0 or greater for datamocktool>=0.1.8
+    * 0.19.2 or greater for datamocktool<0.1.8
 * BigQuery, Redshift, Postgres, or SQL Server (likely works on Snowflake but has not been specifically tested)
 
 ## Quickstart

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -14,10 +14,10 @@ profile: 'datamocktool'
 # These configurations specify where dbt should look for different types of files.
 # The `source-paths` config, for example, states that models in this project can be
 # found in the "models/" directory. You probably won't need to change these!
-source-paths: ["models"]
+model-paths: ["models"]
 analysis-paths: ["analysis"]
 test-paths: ["tests"]
-data-paths: ["data"]
+seed-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 


### PR DESCRIPTION
This is a:
- [X] bug fix PR with no breaking changes
- [ ] new functionality
- [ ] a breaking change

## Description & motivation
Changed the model and seed paths in the top-level `dbt_project.yml`, inline with the DBT docs: https://docs.getdbt.com/docs/guides/migration-guide/upgrading-to-1-0-0#renamed-fields-in-dbt_projectyml

This fixes warnings from DBT version 1.  I thought that #37 fixed these warnings but I was mistaken.

## Checklist
- [X] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [X] Redshift
    - [ ] Snowflake
- [X] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my macros (and models if applicable)
