### PR TITLE
Feature support multiple test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
-# datamocktool
-
+<h1 align="left">datamocktool</h1>
+- [About](#about)
+- [Requirements](#requirements)
+- [Quickstart](#quickstart)
+- [Advanced Usage](#advanced-usage)
+  - [Using Other Materializations](#using-other-materializations)
+  - [Test Names/Descriptions](#test-namesdescriptions)
+  - [Compare Columns](#compare-columns)
+  - [Manual Dependencies](#manual-dependencies)
+  - [Support multiple test cases](#support-multiple-test-cases)
+  - [Visibility on test failure](#visibility-on-test-failure)
 ## About
 
 datamocktool (dmt) is a simple package for unit testing dbt projects.
@@ -183,3 +192,5 @@ This will result in a **single** test being executed. But under the hood, all te
 
 In case of any failures, the **single** test will return a count of errors > 0, making it a "dbt-test failure". The full log will contain a list of all failing tests.
 
+### Visibility on test failure
+TODO: if storing result as a view, it is possible to inspect the mocked model code, making it easier to debug issues with failing tests.

--- a/README.md
+++ b/README.md
@@ -157,3 +157,29 @@ models:
             - ref('raw_customers')
     columns: ...
 ```
+
+### Support multiple test cases
+
+It is also possible to support the same model unit test over multiple test cases. Keeping the yaml config concise, but still easily identifying the specific test cases that are failing.
+
+* `test_case_list`: new optional field, expects an array with the test cases to be applied on `input_mapping` and `expected_output`
+* `@`: The special character to be used as template for string substitution, iterating through the values of `test_case_list`
+* `\`: the special character added to the beginning of the value. This is required to stop Jinja automatically rendering the value (i.e: `ref()`, `source()` etc.)
+
+```yaml
+models:
+  - name: stg_customers
+    tests:
+      - dbt_datamocktool.unit_test:
+          tags: 
+            - example_tag_unit_test 
+          test_case_list: [1,2,3,5,8,13,21]
+          input_mapping:
+            source('jaffle_shop', 'raw_customers'): \ref('dmt__raw_customers_@')
+          expected_output: \ref('dmt__expected_stg_customers_@')
+```
+
+This will result in a **single** test being executed. But under the hood, all test cases listed are checked. Any error count is passed as the test output.
+
+In case of any failures, the **single** test will return a count of errors > 0, making it a "dbt-test failure". The full log will contain a list of all failing tests.
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 <h1 align="left">datamocktool</h1>
+
 - [About](#about)
 - [Requirements](#requirements)
 - [Quickstart](#quickstart)
@@ -7,7 +8,7 @@
   - [Test Names/Descriptions](#test-namesdescriptions)
   - [Compare Columns](#compare-columns)
   - [Manual Dependencies](#manual-dependencies)
-  - [Support multiple test cases](#support-multiple-test-cases)
+  - [Multiple test cases](#multiple-test-cases)
   - [Visibility on test failure](#visibility-on-test-failure)
 ## About
 
@@ -167,9 +168,9 @@ models:
     columns: ...
 ```
 
-### Support multiple test cases
+### Multiple test cases
 
-It is also possible to support the same model unit test over multiple test cases. Keeping the yaml config concise, but still easily identifying the specific test cases that are failing.
+It is also possible to support the same model unit test over multiple test cases.
 
 * `test_case_list`: new optional field, expects an array with the test cases to be applied on `input_mapping` and `expected_output`
 * `@`: The special character to be used as template for string substitution, iterating through the values of `test_case_list`
@@ -193,4 +194,6 @@ This will result in a **single** test being executed. But under the hood, all te
 In case of any failures, the **single** test will return a count of errors > 0, making it a "dbt-test failure". The full log will contain a list of all failing tests.
 
 ### Visibility on test failure
-TODO: if storing result as a view, it is possible to inspect the mocked model code, making it easier to debug issues with failing tests.
+The final mocked model, where the input mapping takes place is stored as a view. This allows to inspect the underlying code, making it easier to debug issues with failing tests.
+
+Additionally, you can export the results of the mocked model and expected output seed - performing a `diff` analysis to easily spot incorrect values.

--- a/macros/dmt_get_test_sql.sql
+++ b/macros/dmt_get_test_sql.sql
@@ -1,4 +1,4 @@
-{% macro get_unit_test_sql(model, input_mapping, depends_on) %}
+{% macro get_unit_test_sql(model, input_mapping, depends_on, test_case=none) %}
     {% set ns=namespace(
         test_sql="(select 1) raw_sql",
         rendered_keys={},
@@ -42,12 +42,6 @@
         {# Create view to expose full definition #}
         {% do run_query(create_view_as(relation, ns.test_sql)) %}
 
-        {# FIXME: commenting out as not sure best way to incorporate the dispatch pattern #}
-        {# {% set mock_model_relation = dbt_datamocktool._get_model_to_mock(
-            model, suffix=('_dmt_' ~ modules.datetime.datetime.now().strftime("%S%f"))
-        ) %}
-
-        {% do dbt_datamocktool._create_mock_table_or_view(mock_model_relation, ns.test_sql) %} #}
     {% endif %}
 
     {% for k in depends_on %}
@@ -55,43 +49,4 @@
     {% endfor %}
     
     {{ mock_model_relation }}
-{% endmacro %}
-
-
-{% macro _get_model_to_mock(model, suffix) %}
-    {{ return(adapter.dispatch('_get_model_to_mock', 'dbt_datamocktool')(model, suffix)) }}
-{% endmacro %}
-
-{% macro default___get_model_to_mock(model, suffix) %}
-    {{ return(make_temp_relation(model.incorporate(type='table'), suffix=suffix)) }}
-{% endmacro %}
-
-{# Spark-specific logic excludes a schema name in order to fix https://github.com/mjirv/dbt-datamocktool/issues/22 #}
-{% macro spark___get_model_to_mock(model, suffix) %}
-    {{ return(make_temp_relation(model.incorporate(type='table').include(schema=False), suffix=suffix)) }}
-{% endmacro %}
-
-{# SQL Server logic creates a view instead of a temp table to fix https://github.com/mjirv/dbt-datamocktool/issues/42 #}
-{% macro sqlserver___get_model_to_mock(model, suffix) %}
-    {% set schema = "datamocktool_tmp" %}
-    {% if not adapter.check_schema_exists(database=model.database, schema=schema) %}
-        {% do adapter.create_schema(api.Relation.create(database=model.database, schema=schema)) %}
-    {% endif %}
-    {% set tmp_identifier = model.identifier ~ suffix %}
-    {# SQL Server requires us to specify a table type because it calls `drop_relation_script()` from `create_table_as()`.
-    I'd prefer to use something like RelationType.table, but can't find a way to access the relation types #}
-    {{ return(model.incorporate(type='view', path={"identifier": tmp_identifier, "schema": schema})) }}
-{% endmacro %}
-
-
-{% macro _create_mock_table_or_view(model, test_sql) %}
-    {{ return(adapter.dispatch('_create_mock_table_or_view', 'dbt_datamocktool')(model, test_sql)) }}
-{% endmacro %}
-
-{% macro default___create_mock_table_or_view(model, test_sql) %}
-    {% do run_query(create_table_as(True, model, test_sql)) %}
-{% endmacro %}
-
-{% macro sqlserver___create_mock_table_or_view(model, test_sql) %}
-    {% do run_query(create_view_as(model, test_sql)) %}
 {% endmacro %}

--- a/macros/dmt_unit_test.sql
+++ b/macros/dmt_unit_test.sql
@@ -1,9 +1,55 @@
-{% test unit_test(model, input_mapping, expected_output, name, description, compare_columns, depends_on) %}
-    {% set test_sql = dbt_datamocktool.get_unit_test_sql(model, input_mapping, depends_on)|trim %}
-    {% do return(dbt_utils.test_equality(expected_output, compare_model=test_sql, compare_columns=compare_columns)) %}
+{% macro individual_unit_test(model, input_mapping, expected_output, test_case) %}
+
+  {% set new_input_mapping = dict() %}
+  {% for k, v in input_mapping.items() %}
+    {# String substitution on the templated value #}
+    {% set templated_value = v|replace('@', test_case)|replace('\\', '') %}
+
+    {# Update copy of dictionary #}
+    {% do new_input_mapping.update({k: render('{{' ~ templated_value ~ '}}')}) %}
+  {% endfor %}
+  
+  {# Retrieve the SQL code with the input mapping applied, using mocked input #}
+  {% set test_sql = get_unit_test_sql(model=model, input_mapping=new_input_mapping, test_case=test_case) %}
+
+  {# equality test expects a Relation #}
+  {% set full_path = render('{{' ~ expected_output|replace('@', test_case)|replace('\\', '') ~ '}}') %}
+  {% set full_path_list = full_path.split('.') %}
+  {% set expected_output = adapter.get_relation(*full_path_list) %}
+  
+  {# Retrieve the SQL code that compares the results between model and expected result #}
+  {% do return(dbt_utils.test_equality(expected_output, compare_model=test_sql)) %}
+
+{% endmacro %}
+---
+{% test unit_test(model, input_mapping, expected_output, test_case_list = []) %}
+    {# Support iterating through list of test cases #}
+    {% if test_case_list %}
+    {% set error_count = namespace(value=0) %}
+      {% for test_case in test_case_list %}
+        {% set unit_test_sql = individual_unit_test(model, input_mapping, expected_output, test_case) %}
+        {% if execute %}
+          {% set test_difference_count = run_query(unit_test_sql).columns[0].values()[0] %}
+        {% else %}
+          {% set test_difference_count = 0 %}
+        {% endif %}
+
+        {% if test_difference_count > 0 %}
+          {# log errors with red font #}
+          {{ log('\033[31m    [ERROR] >> TEST CASE FAILED: ' ~ test_case ~ ' | Number of incorrect records = ' ~ test_difference_count ~ '\033[m', info=True) }}
+          {% set error_count.value = error_count.value + 1 %}
+        {% endif %}
+      {% endfor %}
+
+      {% do return('select '~ error_count.value) %}  
+      
+    {% else %}
+    {# Backwards compatible #}
+        {% set test_sql = custom_get_unit_test_sql(model, input_mapping) %}
+        {% do return(dbt_utils.test_equality(expected_output, compare_model=test_sql)) %}
+    {% endif %}
 {% endtest %}
 
 {% test assert_mock_eq(model, input_mapping, expected_output) %}
     {% do return(test_unit_test(model, input_mapping, expected_output)) %}
 {% endtest %}
-


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes
- [x] new functionality
- [ ] a breaking change

## Description & motivation
Addressing [this issue](https://github.com/mjirv/dbt-datamocktool/issues/53), enables to define a test once, to be applied over multiple test cases.

Applicable when there are multiple test case scenarios, where the mocked input and expected output data (seed) represent a single case, having the seed file names identified by `test_case_1`, `test_case_2` etc.

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my macros (and models if applicable) -> added descriptions. Not sure how to add tests

## Additional comments
1. I am not sure what is the best way to adapt the proposed code change to the new dispatch pattern. I developed these changes against an old package version (`v 0.1.2`). I marked it with the comment `{% FIXME: ...`

2. Also, I have changed the `get_test` macro behavior to always store the mocked model output as a view, which provides better visibility on failing tests. As a `view`, it is possible to inspect its definition, quickly debugging any issues

> **Note**: this is my first time contributing to an open-source project 🎉! Please let me know if there is anything else I could/should do 👍
