### PR TITLE
feat: Support multiple test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
-# datamocktool
+<h1 align="left">datamocktool</h1>
 
+- [About](#about)
+- [Requirements](#requirements)
+- [Quickstart](#quickstart)
+- [Advanced Usage](#advanced-usage)
+  - [Using Other Materializations](#using-other-materializations)
+  - [Test Names/Descriptions](#test-namesdescriptions)
+  - [Compare Columns](#compare-columns)
+  - [Manual Dependencies](#manual-dependencies)
+  - [Multiple test cases](#multiple-test-cases)
 ## About
 
 datamocktool (dmt) is a simple package for unit testing dbt projects.
@@ -157,3 +166,28 @@ models:
             - ref('raw_customers')
     columns: ...
 ```
+
+### Multiple test cases
+
+It is also possible to support the same model unit test over multiple test cases.
+
+* `test_case_list`: new optional field, expects an array with the test cases to be applied on `input_mapping` and `expected_output`
+* `@`: The special character to be used as template for string substitution, iterating through the values of `test_case_list`
+* `\`: the special character added to the beginning of the value. This is required to stop Jinja automatically rendering the value (i.e: `ref()`, `source()` etc.)
+
+```yaml
+models:
+  - name: stg_customers
+    tests:
+      - dbt_datamocktool.unit_test:
+          tags: 
+            - example_tag_unit_test 
+          test_case_list: [1,2,3,5,8,13,21]
+          input_mapping:
+            source('jaffle_shop', 'raw_customers'): \ref('dmt__raw_customers_@')
+          expected_output: \ref('dmt__expected_stg_customers_@')
+```
+
+This will result in a **single** test being executed. But under the hood, all test cases listed are checked. Any error count is passed as the test output.
+
+In case of any failures, the **single** test will return a count of errors > 0, making it a "dbt-test failure". The full log will contain a list of all failing tests.

--- a/macros/dmt_unit_test.sql
+++ b/macros/dmt_unit_test.sql
@@ -1,9 +1,50 @@
-{% test unit_test(model, input_mapping, expected_output, name, description, compare_columns, depends_on) %}
-    {% set test_sql = dbt_datamocktool.get_unit_test_sql(model, input_mapping, depends_on)|trim %}
-    {% do return(dbt_utils.test_equality(expected_output, compare_model=test_sql, compare_columns=compare_columns)) %}
+{% test unit_test(model, input_mapping, expected_output, name, description, compare_columns, depends_on, test_case_list = []) %}
+    {# Support iterating through list of test cases #}
+    {% if test_case_list %}
+    {% set error_count = namespace(value=0) %}
+      {% for test_case in test_case_list %}        
+        {# String substitution for inputs #}
+        {% set individual_input_mapping = dict() %}
+        {% for k, v in input_mapping.items() %}
+          {# String substitution on the templated value #}
+          {% set templated_value = v|replace('@', test_case)|replace('\\', '') %}
+          {# Update copy of dictionary #}
+          {% do individual_input_mapping.update({k: render('{{' ~ templated_value ~ '}}')}) %}
+        {% endfor %}
+
+        {# String substitution for expected output #}
+        {# Equality test expects a Relation #}
+        {% set full_path = render('{{' ~ expected_output|replace('@', test_case)|replace('\\', '') ~ '}}') %}
+        {% set full_path_list = full_path.split('.') %}
+        {% set individual_expected_output = adapter.get_relation(*full_path_list) %}
+
+        {# Retrieve the SQL code with the input mapping applied, using mocked input #}
+        {% set individual_test_sql = dbt_datamocktool.get_unit_test_sql(model, individual_input_mapping, depends_on, test_case) %}
+        {# Retrieve the SQL code that compares the results between model and expected result #}
+        {% set comparison_sql = dbt_utils.test_equality(individual_expected_output, compare_model=individual_test_sql, compare_columns=compare_columns) %}
+
+        {% if execute %}
+          {% set test_difference_count = run_query(comparison_sql).columns[0].values()[0] %}
+        {% else %}
+          {% set test_difference_count = 0 %}
+        {% endif %}
+
+        {% if test_difference_count > 0 %}
+          {# log errors with red font #}
+          {{ log('\033[31m    [ERROR] >> TEST CASE FAILED: ' ~ test_case ~ ' | Number of incorrect records = ' ~ test_difference_count ~ '\033[m', info=True) }}
+          {% set error_count.value = error_count.value + 1 %}
+        {% endif %}
+      {% endfor %}
+
+      {% do return('select '~ error_count.value) %}  
+      
+    {% else %}
+    {# Backwards compatible when not using multiple test_case list #}
+        {% set test_sql = dbt_datamocktool.get_unit_test_sql(model, input_mapping, depends_on)|trim %}
+        {% do return(dbt_utils.test_equality(expected_output, compare_model=test_sql, compare_columns=compare_columns)) %}
+    {% endif %}
 {% endtest %}
 
 {% test assert_mock_eq(model, input_mapping, expected_output) %}
     {% do return(test_unit_test(model, input_mapping, expected_output)) %}
 {% endtest %}
-


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes
- [x] new functionality
- [ ] a breaking change

## Description & motivation
Addressing [this issue](https://github.com/mjirv/dbt-datamocktool/issues/53), enables to define a test once, to be applied over multiple test cases.

Applicable when there are multiple test case scenarios, where the mocked input and expected output data (seed) represent a single case, having the seed file names identified by `test_case_1`, `test_case_2` etc.

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my macros (and models if applicable) -> added descriptions. Not sure how to add tests

## Additional comments
Splitting the original PR into two separate ones: this one focus on enabling **multiple test cases** within a single test definition