### PR TITLE
To conform changes in dbt-core 1.3

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -6,7 +6,7 @@ name: 'dbt_datamocktool'
 version: '0.1.10'
 config-version: 2
 
-require-dbt-version: [">=0.19.2"] # weird behavior/errors with the ref() function before 0.19.2
+require-dbt-version: [">=1.3.0"] # weird behavior/errors with the ref() function before 0.19.2
 
 # This setting configures which "profile" dbt uses for this project.
 profile: 'datamocktool'

--- a/macros/dmt_get_test_sql.sql
+++ b/macros/dmt_get_test_sql.sql
@@ -1,6 +1,6 @@
 {% macro get_unit_test_sql(model, input_mapping, depends_on) %}
     {% set ns=namespace(
-        test_sql="(select 1) raw_sql",
+        test_sql="(select 1) raw_code",
         rendered_keys={},
         graph_model=none
     ) %}
@@ -21,7 +21,7 @@
                 {% endif %}
             {% endfor %}
         {% endif %}
-        {% set ns.test_sql = ns.graph_model.raw_sql %}
+        {% set ns.test_sql = ns.graph_model.raw_code %}
 
         {% for k,v in input_mapping.items() %}
             {# render the original sql and replacement key before replacing because v is already rendered when it is passed to this test #}

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: [">=0.6.3"]
+    version: [">=0.9.0"]


### PR DESCRIPTION
This is a:
- [x] a breaking change

## Description & motivation
Implements minimal changes to `get_unit_test_sql` macro to conform with the changes in `dbt-core` 1.3. Bumped up `dbt-core` requirements and `dbt-utils` dependency. Did not update README, as I believe that this probably should merit a new release of the package.

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my macros (and models if applicable)
