### PR TITLE
Added macros building a test report out of the unit test.

### DIFF
--- a/integration_tests/packages.yml
+++ b/integration_tests/packages.yml
@@ -1,2 +1,4 @@
 packages:
   - local: ../
+  - package: dbt-labs/audit_helper
+    version: 0.7.0

--- a/integration_tests/packages.yml
+++ b/integration_tests/packages.yml
@@ -1,4 +1,2 @@
 packages:
   - local: ../
-  - package: dbt-labs/audit_helper
-    version: 0.7.0

--- a/macros/dmt_get_test_sql.sql
+++ b/macros/dmt_get_test_sql.sql
@@ -21,7 +21,7 @@
                 {% endif %}
             {% endfor %}
         {% endif %}
-        {% set ns.test_sql = ns.graph_model.raw_sql %}
+        {% set ns.test_sql = ns.graph_model.raw_code %}
 
         {% for k,v in input_mapping.items() %}
             {# render the original sql and replacement key before replacing because v is already rendered when it is passed to this test #}
@@ -71,11 +71,11 @@
 
 {% macro _create_mock_table_or_view(model, test_sql) %}
     {{ return(adapter.dispatch('_create_mock_table_or_view', 'dbt_datamocktool')(model, test_sql)) }}
-{% endmacro %}
+    {% endmacro %}
 
 {% macro default___create_mock_table_or_view(model, test_sql) %}
     {% do run_query(create_table_as(True, model, test_sql)) %}
-{% endmacro %}
+    {% endmacro %}
 
 {% macro sqlserver___create_mock_table_or_view(model, test_sql) %}
     {% do run_query(create_view_as(model, test_sql)) %}

--- a/macros/dmt_unit_test.sql
+++ b/macros/dmt_unit_test.sql
@@ -1,106 +1,74 @@
 {%- test unit_test(model, input_mapping, expected_output, name, description, compare_columns, depends_on) -%}
     {%- set test_sql = dbt_datamocktool.get_unit_test_sql(model, input_mapping, depends_on)|trim -%}
-
     {%- set test_report = dbt_datamocktool.test_equality(expected_output, name, compare_model=test_sql, compare_columns=compare_columns) -%}
-    {%- do return(test_report) -%}
+    {{ test_report }}
 {%- endtest -%}
 
 
 {%- macro test_equality(model, name, compare_model, compare_columns=None) -%}
 
-{%- set set_diff -%}
-    count(*) + coalesce(abs(
-        sum(case when which_diff = 'a_minus_b' then 1 else 0 end) -
-        sum(case when which_diff = 'b_minus_a' then 1 else 0 end)
-    ), 0)
-{%- endset -%}
+    {#-- Prevent querying of db in parsing mode. This works because this macro does not create any new refs. #}
+    {%- if not execute -%}
+        {{ return('') }}
+    {%- endif -%}
 
-{#-- Needs to be set at parse time, before we return '' below --#}
-{{ config(fail_calc = set_diff) }}
+    {#- setup -#}
+    {%- do dbt_utils._is_relation(model, 'test_equality') -%}
+    {#-
+    If the compare_cols arg is provided, we can run this test without querying the
+    information schema — this allows the model to be an ephemeral model
+    -#}
+    {%- if not compare_columns -%}
+        {%- do dbt_utils._is_ephemeral(model, 'test_equality') -%}
+        {%- set exclude_columns = [] -%}
+    {%- else -%}
+        {%- set all_columns = adapter.get_columns_in_relation(model) | map(attribute='quoted')  -%}
+        {%- set exclude_columns = [] -%}
+        {%- for col in all_columns -%}
+            {%- set col = col|replace('"',"") -%}
+            {%- if col not in compare_columns|upper -%}
+                {%- do exclude_columns.append(col) -%}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endif -%}
 
-{#-- Prevent querying of db in parsing mode. This works because this macro does not create any new refs. #}
-{%- if not execute -%}
-    {{ return('') }}
-{%- endif -%}
-
--- setup
-{%- do dbt_utils._is_relation(model, 'test_equality') -%}
-
-{#-
-If the compare_cols arg is provided, we can run this test without querying the
-information schema — this allows the model to be an ephemeral model
--#}
-
-{%- if not compare_columns -%}
-    {%- do dbt_utils._is_ephemeral(model, 'test_equality') -%}
-    {%- set compare_columns = adapter.get_columns_in_relation(model) | map(attribute='quoted') -%}
-{%- endif -%}
-
-{%- set compare_cols_csv = compare_columns | join(', ') -%}
-
-{%- set tables_compared -%}
-with a as (
-
-    select * from {{ model }}
-
-),
-
-b as (
-
-    select * from {{ compare_model }}
-
-),
-
-a_minus_b as (
-
-    select {{compare_cols_csv}} from a
-    {{ dbt.except() }}
-    select {{compare_cols_csv}} from b
-
-),
-
-b_minus_a as (
-
-    select {{compare_cols_csv}} from b
-    {{ dbt.except() }}
-    select {{compare_cols_csv}} from a
-
-),
-
-unioned as (
-
-    select 'actual' as which_diff, b_minus_a.* from b_minus_a
-    union all
-    select 'expected' as which_diff, a_minus_b.* from a_minus_b
-
-)
-
-select * from unioned
-{%- endset -%}
+    {%- set tables_compared -%}
+    {{ audit_helper.compare_relations(
+        a_relation = model,
+        b_relation = compare_model,
+        exclude_columns = exclude_columns,
+        summarize = False
+    ) }}
+    {%- endset -%}
 
     {#- Run the comparison query -#}
     {%- set test_report = run_query(tables_compared) -%}
-    {#- Print output if there are any rows within the table. -#}
     {%- if test_report.columns[0].values()|length -%}
+        {%- set test_status = 1 -%}
+    {%- else -%}
+        {%- set test_status = 0 -%}
+    {%- endif-%}
+
+    {#- Print output if there are any rows within the table. -#}
+    {%- if test_status == 1 -%}
         {{ dbt_datamocktool.print_color('{YELLOW}The test <' ~ name ~ '> failed with the differences:') }}
         {{ dbt_datamocktool.print_color('{RED}================================================================') }}
         {% do test_report.print_table() %}
-    {{ dbt_datamocktool.print_color('{RED}================================================================') }}
+        {{ dbt_datamocktool.print_color('{RED}================================================================') }}
     {%- endif -%}
 
-{{ return(tables_compared) }}
+    {{ return(tables_compared) }}
 {%- endmacro -%}
-
 
 
 {% macro print_color(string) %}
   {% do log(dbt_datamocktool.parse_colors(string ~ "{RESET}"), info=true) %}
 {% endmacro %}
 
+
 {% macro parse_colors(string) %}
   {{ return (string
       .replace("{RED}", "\x1b[0m\x1b[31m")
-      .replace("{GREEN}", "\x1b[0m\x1b[32m")
       .replace("{YELLOW}", "\x1b[0m\x1b[33m")
       .replace("{RESET}", "\x1b[0m")) }}
 {% endmacro %}

--- a/macros/dmt_unit_test.sql
+++ b/macros/dmt_unit_test.sql
@@ -1,9 +1,106 @@
-{% test unit_test(model, input_mapping, expected_output, name, description, compare_columns, depends_on) %}
-    {% set test_sql = dbt_datamocktool.get_unit_test_sql(model, input_mapping, depends_on)|trim %}
-    {% do return(dbt_utils.test_equality(expected_output, compare_model=test_sql, compare_columns=compare_columns)) %}
-{% endtest %}
+{%- macro unit_test(model, input_mapping, expected_output, name, description, compare_columns, depends_on) -%}
+    {%- set test_sql = get_unit_test_sql(model, input_mapping, depends_on)|trim -%}
 
-{% test assert_mock_eq(model, input_mapping, expected_output) %}
-    {% do return(test_unit_test(model, input_mapping, expected_output)) %}
-{% endtest %}
+    {%- set test_report = test_equality(expected_output, name, compare_model=test_sql, compare_columns=compare_columns) -%}
+    {%- do return(test_report) -%}
+{%- endmacro -%}
 
+
+{%- macro test_equality(model, name, compare_model, compare_columns=None) -%}
+
+{%- set set_diff -%}
+    count(*) + coalesce(abs(
+        sum(case when which_diff = 'a_minus_b' then 1 else 0 end) -
+        sum(case when which_diff = 'b_minus_a' then 1 else 0 end)
+    ), 0)
+{%- endset -%}
+
+{#-- Needs to be set at parse time, before we return '' below --#}
+{{ config(fail_calc = set_diff) }}
+
+{#-- Prevent querying of db in parsing mode. This works because this macro does not create any new refs. #}
+{%- if not execute -%}
+    {{ return('') }}
+{%- endif -%}
+
+-- setup
+{%- do dbt_utils._is_relation(model, 'test_equality') -%}
+
+{#-
+If the compare_cols arg is provided, we can run this test without querying the
+information schema — this allows the model to be an ephemeral model
+-#}
+
+{%- if not compare_columns -%}
+    {%- do dbt_utils._is_ephemeral(model, 'test_equality') -%}
+    {%- set compare_columns = adapter.get_columns_in_relation(model) | map(attribute='quoted') -%}
+{%- endif -%}
+
+{%- set compare_cols_csv = compare_columns | join(', ') -%}
+
+{%- set tables_compared -%}
+with a as (
+
+    select * from {{ model }}
+
+),
+
+b as (
+
+    select * from {{ compare_model }}
+
+),
+
+a_minus_b as (
+
+    select {{compare_cols_csv}} from a
+    {{ dbt.except() }}
+    select {{compare_cols_csv}} from b
+
+),
+
+b_minus_a as (
+
+    select {{compare_cols_csv}} from b
+    {{ dbt.except() }}
+    select {{compare_cols_csv}} from a
+
+),
+
+unioned as (
+
+    select 'actual' as which_diff, b_minus_a.* from b_minus_a
+    union all
+    select 'expected' as which_diff, a_minus_b.* from a_minus_b
+
+)
+
+select * from unioned
+{%- endset -%}
+
+    {#- Run the comparison query -#}
+    {%- set test_report = run_query(tables_compared) -%}
+    {#- Print output if there are any rows within the table. -#}
+    {%- if test_report.columns[0].values()|length -%}
+        {{ print_color('{YELLOW}The test <' ~ name ~ '> failed with the differences:') }}
+        {{ print_color('{RED}================================================================') }}
+        {% do test_report.print_table() %}
+    {{ print_color('{RED}================================================================') }}
+    {%- endif -%}
+
+{{ return(tables_compared) }}
+{%- endmacro -%}
+
+
+
+{% macro print_color(string) %}
+  {% do log(parse_colors(string ~ "{RESET}"), info=true) %}
+{% endmacro %}
+
+{% macro parse_colors(string) %}
+  {{ return (string
+      .replace("{RED}", "\x1b[0m\x1b[31m")
+      .replace("{GREEN}", "\x1b[0m\x1b[32m")
+      .replace("{YELLOW}", "\x1b[0m\x1b[33m")
+      .replace("{RESET}", "\x1b[0m")) }}
+{% endmacro %}

--- a/macros/dmt_unit_test.sql
+++ b/macros/dmt_unit_test.sql
@@ -1,9 +1,9 @@
-{%- macro unit_test(model, input_mapping, expected_output, name, description, compare_columns, depends_on) -%}
-    {%- set test_sql = get_unit_test_sql(model, input_mapping, depends_on)|trim -%}
+{%- test unit_test(model, input_mapping, expected_output, name, description, compare_columns, depends_on) -%}
+    {%- set test_sql = dbt_datamocktool.get_unit_test_sql(model, input_mapping, depends_on)|trim -%}
 
-    {%- set test_report = test_equality(expected_output, name, compare_model=test_sql, compare_columns=compare_columns) -%}
+    {%- set test_report = dbt_datamocktool.test_equality(expected_output, name, compare_model=test_sql, compare_columns=compare_columns) -%}
     {%- do return(test_report) -%}
-{%- endmacro -%}
+{%- endtest -%}
 
 
 {%- macro test_equality(model, name, compare_model, compare_columns=None) -%}
@@ -82,10 +82,10 @@ select * from unioned
     {%- set test_report = run_query(tables_compared) -%}
     {#- Print output if there are any rows within the table. -#}
     {%- if test_report.columns[0].values()|length -%}
-        {{ print_color('{YELLOW}The test <' ~ name ~ '> failed with the differences:') }}
-        {{ print_color('{RED}================================================================') }}
+        {{ dbt_datamocktool.print_color('{YELLOW}The test <' ~ name ~ '> failed with the differences:') }}
+        {{ dbt_datamocktool.print_color('{RED}================================================================') }}
         {% do test_report.print_table() %}
-    {{ print_color('{RED}================================================================') }}
+    {{ dbt_datamocktool.print_color('{RED}================================================================') }}
     {%- endif -%}
 
 {{ return(tables_compared) }}
@@ -94,7 +94,7 @@ select * from unioned
 
 
 {% macro print_color(string) %}
-  {% do log(parse_colors(string ~ "{RESET}"), info=true) %}
+  {% do log(dbt_datamocktool.parse_colors(string ~ "{RESET}"), info=true) %}
 {% endmacro %}
 
 {% macro parse_colors(string) %}

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,5 @@
 packages:
   - package: dbt-labs/dbt_utils
     version: [">=0.6.3"]
+  - package: dbt-labs/audit_helper
+    version: 0.7.0


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes
- [x] new functionality
- [ ] a breaking change

## Description & motivation
The standard unit test is only comparing the entire table and telling you at the end that the contents do not match. However, they error message does not point out the column with the different values. By adding some macros inspired by the dbt original unit test one can compare the columns with each other and that way can easily see what actually caused the error. That speeds up debugging a lot.

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my macros (and models if applicable)
