### PR TITLE
bug fix compare columns 

### DIFF
--- a/integration_tests/data/dmt_unit_test_seeds/test_suite_1/dmt__expected_stg_customers_1.csv
+++ b/integration_tests/data/dmt_unit_test_seeds/test_suite_1/dmt__expected_stg_customers_1.csv
@@ -1,3 +1,3 @@
-customer_id,first_name,last_name
-1,Michael,P.
-2,Shawn,M.
+customer_id,first_name,last_name,description
+1,Michael,P.,this column is to be excluded for comparison - do not compare this column in test
+2,Shawn,M.,empty description

--- a/integration_tests/models/staging/schema.yml
+++ b/integration_tests/models/staging/schema.yml
@@ -12,6 +12,10 @@ models:
           input_mapping:
             source('jaffle_shop', 'raw_customers'): ref('dmt__raw_customers_1') # this is a seed
           expected_output: ref('dmt__expected_stg_customers_1') # this is also a seed
+          compare_columns:
+            - customer_id
+            - first_name
+            - last_name
       - dbt_datamocktool.unit_test:
           input_mapping:
             source('jaffle_shop', 'raw_customers'): "{{ dmt_raw_customers() }}" # this is a macro

--- a/macros/dmt_unit_test.sql
+++ b/macros/dmt_unit_test.sql
@@ -31,7 +31,9 @@
         {%- set exclude_columns = [] -%}
         {%- for col in all_columns -%}
             {%- set col = col|replace('"',"") -%}
-            {%- if col not in compare_columns|upper -%}
+            {# -- in bigquery columns seem to come quoted with ` #}
+            {%- set col = col|replace('`',"") -%}
+            {%- if col|upper not in compare_columns|upper -%}
                 {%- do exclude_columns.append(col) -%}
             {%- endif -%}
         {%- endfor -%}


### PR DESCRIPTION
This is a:
- [X] bug fix PR with no breaking changes
- [ ] new functionality
- [ ] a breaking change

## Description & motivation
I tried to solve the bug with compare columns in 0.3.0 https://github.com/mjirv/dbt-datamocktool/issues/66

Column seem to come backticked in bigquery with the current collection of columns to generate "exclude columns" in comparisons. 

Why the upper filter is used only on one side of the comparisonI don't know, but I added an upper filter to both sides. 

## Checklist
- [X] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [X] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I have updated the README.md (if applicable)
- [X] I have added tests & descriptions to my macros (and models if applicable)
