### PR TITLE
Feature: exclude columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ will show up in your test run as follows:
 21:37:49 | 4 of 23 PASS dbt_datamocktool_unit_test_stg_customers_This_test_is_a_unit_test__ref_dmt__expected_stg_customers_2____dmt_raw_customers___Raw_Customers_2 [PASS in 0.27s]
 ```
 
-### Compare Columns
+### Include/exclude columns
 
 If you only want to mock a few columns, you can do so and use the `compare_columns` field to tell the test which columns to look at, like so:
 
@@ -139,7 +139,20 @@ models:
           compare_columns:
             - first_name
             - last_name
-    columns: ...
+```
+
+Alternatively, if you want to compare all columns apart from a few, you can use the `exclude_columns` field:
+
+```yaml
+models:
+  - name: stg_customers
+    tests:
+      - dbt_datamocktool.unit_test:
+          input_mapping:
+            source('jaffle_shop', 'raw_customers'): ref('dmt__raw_customers_1')
+          expected_output: ref('dmt__expected_stg_customers_1')
+          exclude_columns:
+            - description
 ```
 
 ### Manual Dependencies

--- a/integration_tests/data/dmt_unit_test_seeds/test_suite_1/dmt__raw_customers_1.csv
+++ b/integration_tests/data/dmt_unit_test_seeds/test_suite_1/dmt__raw_customers_1.csv
@@ -1,3 +1,3 @@
-id,first_name,last_name
-1,Michael,P.
-2,Shawn,M.
+id,first_name,last_name,description
+1,Michael,P.,this description will not match the expected description
+2,Shawn,M.,empty description

--- a/integration_tests/models/staging/schema.yml
+++ b/integration_tests/models/staging/schema.yml
@@ -18,6 +18,12 @@ models:
             - last_name
       - dbt_datamocktool.unit_test:
           input_mapping:
+            source('jaffle_shop', 'raw_customers'): ref('dmt__raw_customers_1') # this is a seed
+          expected_output: ref('dmt__expected_stg_customers_1') # this is also a seed
+          exclude_columns: # exactly the same test as above
+            - description
+      - dbt_datamocktool.unit_test:
+          input_mapping:
             source('jaffle_shop', 'raw_customers'): "{{ dmt_raw_customers() }}" # this is a macro
           expected_output: ref('dmt__expected_stg_customers_2') # this is a model
           name: "Raw Customers 2"

--- a/macros/dmt_unit_test.sql
+++ b/macros/dmt_unit_test.sql
@@ -1,42 +1,44 @@
-{%- test unit_test(model, input_mapping, expected_output, name, description, compare_columns, depends_on) -%}
+{%- test unit_test(model, input_mapping, expected_output, name, description, compare_columns, exclude_columns, depends_on) -%}
     {%- set test_sql = dbt_datamocktool.get_unit_test_sql(model, input_mapping, depends_on)|trim -%}
-    {%- set test_report = dbt_datamocktool.test_equality(expected_output, name, compare_model=test_sql, compare_columns=compare_columns) -%}
+    {%- set test_report = dbt_datamocktool.test_equality(expected_output, name, compare_model=test_sql, compare_columns=compare_columns, exclude_columns=exclude_columns) -%}
     {{ test_report }}
 {%- endtest -%}
 
-{% test unit_test_incremental(model, input_mapping, expected_output, name, description, compare_columns, depends_on) %}
+{% test unit_test_incremental(model, input_mapping, expected_output, name, description, compare_columns, exclude_columns, depends_on) %}
     {%- set test_sql = dbt_datamocktool.get_unit_test_incremental_sql(model, input_mapping, depends_on)|trim -%}
-    {%- set test_report = dbt_datamocktool.test_equality(expected_output, name, compare_model=test_sql, compare_columns=compare_columns) -%}
+    {%- set test_report = dbt_datamocktool.test_equality(expected_output, name, compare_model=test_sql, compare_columns=compare_columns, exclude_columns=exclude_columns) -%}
     {{ test_report }}
 {% endtest %}
 
-{%- macro test_equality(model, name, compare_model, compare_columns=None) -%}
+{%- macro test_equality(model, name, compare_model, compare_columns=[], exclude_columns=[]) -%}
 
-    {#-- Prevent querying of db in parsing mode. This works because this macro does not create any new refs. #}
+    -- Prevent querying of db in parsing mode. This works because this macro does not create any new refs.
     {%- if not execute -%}
         {{ return('') }}
     {%- endif -%}
 
-    {#- setup -#}
+    -- Setup
     {%- do dbt_utils._is_relation(model, 'test_equality') -%}
-    {#-
-    If the compare_cols arg is provided, we can run this test without querying the
-    information schema — this allows the model to be an ephemeral model
-    -#}
-    {%- if not compare_columns -%}
-        {%- do dbt_utils._is_ephemeral(model, 'test_equality') -%}
-        {%- set exclude_columns = [] -%}
-    {%- else -%}
+    {%- if compare_columns|length and exclude_columns|length -%}
+        {{ exceptions.raise_compiler_error("You cannot provide both compare_columns and exclude_columns") }}
+    {%- endif -%}
+
+    -- If compare_columns have been provided, we need to query the schema to get the list of columns
+    -- to exclude
+    {%- if compare_columns|length -%}
         {%- set all_columns = adapter.get_columns_in_relation(model) | map(attribute='quoted')  -%}
         {%- set exclude_columns = [] -%}
         {%- for col in all_columns -%}
-            {%- set col = col|replace('"',"") -%}
-            {# -- in bigquery columns seem to come quoted with ` #}
+            -- In bigquery columns seem to come quoted with backticks
             {%- set col = col|replace('`',"") -%}
             {%- if col|upper not in compare_columns|upper -%}
                 {%- do exclude_columns.append(col) -%}
             {%- endif -%}
         {%- endfor -%}
+    {%- else -%}
+        -- If we're comparing all columns, or if we're excluding certain columns, then we don't need
+        -- to query the schema, which means the modal can be an ephermeral model
+        {%- do dbt_utils._is_ephemeral(model, 'test_equality') -%}
     {%- endif -%}
 
     {%- set tables_compared -%}
@@ -48,7 +50,7 @@
     ) }}
     {%- endset -%}
 
-    {#- Run the comparison query -#}
+    -- Run the comparison query
     {%- set test_report = run_query(tables_compared) -%}
     {%- if test_report.columns[0].values()|length -%}
         {%- set test_status = 1 -%}
@@ -56,7 +58,7 @@
         {%- set test_status = 0 -%}
     {%- endif-%}
 
-    {#- Print output if there are any rows within the table. -#}
+    -- Print output if there are any rows within the table.
     {%- if test_status == 1 -%}
         {{ dbt_datamocktool.print_color('{YELLOW}The test <' ~ name ~ '> failed with the differences:') }}
         {{ dbt_datamocktool.print_color('{RED}================================================================') }}


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes
- [x] new functionality
- [ ] a breaking change

## Description & motivation
dmt already supports the ability to compare only a subset of columns, and this PR supports the inverse.

I require this because there's an array column in my data that dmt struggles to mock, so I want to exclude it. Currently, I have to list about 15 columns to include, which isn't ideal if someone adds a new column and forgets to update the mock input/output.

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my macros (and models if applicable)
