### PR TITLE
Enable macro unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,3 +183,38 @@ _NOTE: currently only the MERGE strategy is supported, so `unit_test_incremental
           this: ref('dmt__current_state_orders_2')
         expected_output: ref('dmt__expected_stg_orders_2')
 ```
+
+### Set the unit tests as macros
+
+The unit tests can also be defined inside macros. This yields the disadvantage that not all the tests are defined at the same place, i.e. the yml file of the model. However, this allows to easlily run a specific unit test and enables easier selection criterias if the tests are for example run within a ci/cd pipeline, since all the tests can be excluded or included via their folder path within tests/.
+
+To set a new test, a file has to be created within the tests/ folder like that:
+
+```sql
+{{ dbt_datamocktool.unit_test(
+    model = ref('stg_customers'),
+    input_mapping = {
+        source('jaffle_shop', 'raw_customers'): ref('dmt__raw_customers_1')
+    },
+    expected_output = ref('dmt__expected_stg_customers_1'),
+) }}
+```
+
+To make use of the other configuration possibilities, like inlcuding only specific columns, they can be simply added the same then in the yml files. If a specification consists out of multiple items, it has to explicitly be setup as a dictionary. Does one key contain multiple calues, it has to be added as a list. A complete example would look like that:
+
+```sql
+{{ dbt_datamocktool.unit_test(
+  model = ref('<model_to_test>'),
+  input_mapping = {
+        ref('<input_one>'): ref('<replacement_one>'),
+        ref('<input_two>'): ref('<replacement_two>')
+    },
+    expected_output = ref('<expected_output>'),
+    name = '<Name of the unit test>',
+    description = '<Description of the unit test>',
+    compare_columns = ['<col_one>', '<col_two>'],
+    depends_on = [ref('<dependency_one>'), ref('<dependency_two>')],
+)}}
+```
+
+Up to this moment, not multiple tests can defined per file. It can be only one test macro per file.

--- a/integration_tests/tests/unit/staging/test_stg_customers.sql
+++ b/integration_tests/tests/unit/staging/test_stg_customers.sql
@@ -1,0 +1,8 @@
+{#- Unit test with seeds as the input as well as the output. -#}
+{{ dbt_datamocktool.unit_test(
+    model = ref('stg_customers'),
+    input_mapping = {
+        source('jaffle_shop', 'raw_customers'): ref('dmt__raw_customers_1')
+    },
+    expected_output = ref('dmt__expected_stg_customers_1'),
+) }}

--- a/integration_tests/tests/unit/staging/test_stg_customers_macro_input.sql
+++ b/integration_tests/tests/unit/staging/test_stg_customers_macro_input.sql
@@ -1,0 +1,9 @@
+{#- Unit test with macro as the input and a model as the expected output. -#}
+{{ dbt_datamocktool.unit_test(
+    model = ref('stg_customers'),
+    input_mapping = {
+        source('jaffle_shop', 'raw_customers'): "{{ dmt_raw_customers() }}"
+    },
+    expected_output = ref('dmt__expected_stg_customers_2'),
+    name = "This test is a unit test",
+) }}

--- a/integration_tests/tests/unit/staging/test_stg_orders.sql
+++ b/integration_tests/tests/unit/staging/test_stg_orders.sql
@@ -1,0 +1,7 @@
+{{ dbt_datamocktool.unit_test(
+    model = ref('stg_orders'),
+    input_mapping = {
+        ref('raw_orders'): ref('dmt__raw_orders_1')
+    },
+    expected_output = ref('dmt__expected_stg_orders_1'),
+) }}

--- a/integration_tests/tests/unit/staging/test_stg_orders_incremental.sql
+++ b/integration_tests/tests/unit/staging/test_stg_orders_incremental.sql
@@ -1,0 +1,9 @@
+{#- Unit test with for an incremental model with redefining `{{this}}`. -#}
+{{ dbt_datamocktool.unit_test_incremental(
+    model = ref('stg_orders'),
+    input_mapping = {
+            ref('raw_orders'): ref('dmt__raw_orders_3'),
+            "this": ref('dmt__current_state_orders_2')
+    },
+    expected_output = ref('dmt__expected_stg_orders_2'),
+) }}

--- a/macros/dmt_unit_test.sql
+++ b/macros/dmt_unit_test.sql
@@ -1,17 +1,26 @@
-{%- test unit_test(model, input_mapping, expected_output, name, description, compare_columns, depends_on) -%}
+{%- macro unit_test(model, input_mapping, expected_output, name, description, compare_columns, depends_on) -%}
     {%- set test_sql = dbt_datamocktool.get_unit_test_sql(model, input_mapping, depends_on)|trim -%}
     {%- set test_report = dbt_datamocktool.test_equality(expected_output, name, compare_model=test_sql, compare_columns=compare_columns) -%}
     {{ test_report }}
+{%- endmacro -%}
+
+{%- test unit_test(model, input_mapping, expected_output, name, description, compare_columns, depends_on) -%}
+    {{ dbt_datamocktool.unit_test(model, input_mapping, expected_output, name, description, compare_columns, depends_on) }}
 {%- endtest -%}
 
-{% test unit_test_incremental(model, input_mapping, expected_output, name, description, compare_columns, depends_on) %}
+
+{%- macro unit_test_incremental(model, input_mapping, expected_output, name, description, compare_columns, depends_on) -%}
     {%- set test_sql = dbt_datamocktool.get_unit_test_incremental_sql(model, input_mapping, depends_on)|trim -%}
     {%- set test_report = dbt_datamocktool.test_equality(expected_output, name, compare_model=test_sql, compare_columns=compare_columns) -%}
     {{ test_report }}
+{%- endmacro -%}
+
+{% test unit_test_incremental(model, input_mapping, expected_output, name, description, compare_columns, depends_on) %}
+    {{ dbt_datamocktool.unit_test_incremental(model, input_mapping, expected_output, name, description, compare_columns, depends_on) }}
 {% endtest %}
 
-{%- macro test_equality(model, name, compare_model, compare_columns=None) -%}
 
+{%- macro test_equality(model, name, compare_model, compare_columns=None) -%}
     {#-- Prevent querying of db in parsing mode. This works because this macro does not create any new refs. #}
     {%- if not execute -%}
         {{ return('') }}


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes
- [x] new functionality
- [ ] a breaking change

## Description & motivation
Within our team our yml for our dpt project got quite large. If one uses a lot of data tests, documents every column (even if it is centralized using docs) and then adds all the unit tests on top of it, it can be a lot of lines. Therefore, we were looking for a way to outsource all our unit tests inside of macros.
This has the additional benefit that it is very easy to run single a unit test while coding and controlling for possible errors. Furthermore, this makes it possible to run all data and unit tests apart from each other (e.g. in a CI/CD Pipeline) by selecting/excluding all unit tests via their folder path in tests.


## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my macros (and models if applicable)
