### PR TITLE
Support updates in incremental tests

### DIFF
--- a/integration_tests/data/dmt_unit_test_seeds/test_suite_2/dmt__current_state_orders_2.csv
+++ b/integration_tests/data/dmt_unit_test_seeds/test_suite_2/dmt__current_state_orders_2.csv
@@ -1,3 +1,3 @@
 order_id,customer_id,order_date,status
 1,1,2018-01-01,returned
-2,3,2018-01-02,completed
+2,3,2018-01-02,shipped

--- a/integration_tests/models/staging/stg_orders.sql
+++ b/integration_tests/models/staging/stg_orders.sql
@@ -1,4 +1,4 @@
-{{ config(materialized = "incremental") }}
+{{ config(materialized = "incremental", unique_key='order_id') }}
 
 with source as (
 
@@ -8,7 +8,7 @@ with source as (
     #}
     select * from {{ ref('raw_orders') }}
     {% if is_incremental() %}
-        where id > (select max(order_id) from {{ this }})
+        where id > (select max(order_id) from {{ this }}) or id = 2
     {% endif %}
 ),
 


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality
- [ ] a breaking change

## Description & motivation
I had an incremental model that both added and updated rows and I noticed that the update scenario did not work in DMT using `dbt_datamocktool.unit_test_incremental`.

The generated MERGE statement was different between `dbt run` and `dbt test`.

**`dbt run`**
```sql
merge into MY_DB.PUBLIC.third as DBT_INTERNAL_DEST
        using MY_DB.PUBLIC.third__dbt_tmp as DBT_INTERNAL_SOURCE
        on (
                DBT_INTERNAL_SOURCE.id = DBT_INTERNAL_DEST.id
            )
    
    when matched then update set
        "ID" = DBT_INTERNAL_SOURCE."ID","CREATED_ON" = DBT_INTERNAL_SOURCE."CREATED_ON"
   
    when not matched then insert
        ("ID", "CREATED_ON")
    values
        ("ID", "CREATED_ON")

;
```

**`dbt test`**
```sql
merge into MY_DB.PUBLIC.third_dmt_48146351 as DBT_INTERNAL_DEST
        using (
select *
from MY_DB.PUBLIC.dmt__third_input_second
  -- this filter will only be applied on an incremental run
  where created_on > (select max(created_on) from MY_DB.PUBLIC.dmt__third_input_this)
) as DBT_INTERNAL_SOURCE
        on (FALSE)
    when not matched then insert
        ("ID", "CREATED_ON")
    values
        ("ID", "CREATED_ON")
```

I think dbt optimizes the join condition thinking no updates will happen.

I tracked it down to `unique_key` not being passed into `get_merge_sql`. When I pass it, the MERGE statement gets the correct join condition.

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my macros (and models if applicable)
