### PR TITLE
Prevent  querying of db when compiling

### DIFF
--- a/macros/dmt_unit_test.sql
+++ b/macros/dmt_unit_test.sql
@@ -21,7 +21,7 @@
 {%- macro test_equality(model, name, compare_model, compare_columns=[], exclude_columns=[]) -%}
 
     -- Prevent querying of db in parsing mode. This works because this macro does not create any new refs.
-    {%- if not execute -%}
+    {%- if not execute or flags.WHICH == 'compile' -%}
         {{ return('') }}
     {%- endif -%}
 


### PR DESCRIPTION
This is a:
- [ x ] bug fix PR with no breaking changes
- [ ] new functionality
- [ ] a breaking change

## Description & motivation
I keep seeing these weird fake test failures when running dbt compile. Based on this conversion https://github.com/dbt-labs/dbt-core/issues/4575#issuecomment-1017293334 it seems to be because dbt compile sets execute to true during one of its phases. This makes it so that db parsing is also stopped when compiling

## Checklist
- [ x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ x] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my macros (and models if applicable)
